### PR TITLE
Platform: nordic_nrf: Update configurations for psa-arch-tests

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/plat_test.c
+++ b/platform/ext/target/nordic_nrf/common/core/plat_test.c
@@ -91,27 +91,3 @@ void tfm_plat_test_non_secure_timer_stop(void)
 {
     timer_stop(NRF_TIMER1);
 }
-
-#ifdef PSA_API_TEST_ENABLED
-uint32_t pal_nvmem_get_addr(void)
-{
-#ifdef NRF_TRUSTZONE_NONSECURE
-    static bool psa_scratch_initialized = false;
-
-    if (!psa_scratch_initialized) {
-        uint32_t reset_reason = nrfx_reset_reason_get();
-        nrfx_reset_reason_clear(reset_reason);
-
-        int is_pinreset = reset_reason & NRFX_RESET_REASON_RESETPIN_MASK;
-        if ((reset_reason == 0) || is_pinreset){
-            /* PSA API tests expect this area to be initialized to all 0xFFs
-             * after a power-on or pin reset.
-             */
-            memset((void*)PSA_TEST_SCRATCH_AREA_BASE, 0xFF, PSA_TEST_SCRATCH_AREA_SIZE);
-        }
-        psa_scratch_initialized = true;
-    }
-#endif /* NRF_TRUSTZONE_NONSECURE */
-    return (uint32_t)PSA_TEST_SCRATCH_AREA_BASE;
-}
-#endif /* PSA_API_TEST_ENABLED */

--- a/platform/ext/target/nordic_nrf/common/nrf5340/mmio_defs.h
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/mmio_defs.h
@@ -211,6 +211,11 @@ const uintptr_t partition_named_mmio_list[] = {
 #if TFM_PERIPHERAL_VMC_SECURE
     (uintptr_t)TFM_PERIPHERAL_VMC,
 #endif
+#ifdef PSA_API_TEST_IPC
+    (uintptr_t)FF_TEST_NVMEM_REGION,
+    (uintptr_t)FF_TEST_DRIVER_PARTITION_MMIO,
+    (uintptr_t)FF_TEST_SERVER_PARTITION_MMIO,
+#endif
 };
 
 #ifdef __cplusplus

--- a/platform/ext/target/nordic_nrf/common/nrf5340/tfm_interrupts.c
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/tfm_interrupts.c
@@ -679,6 +679,6 @@ enum tfm_hal_status_t tfm_usbreg_irq_init(void *p_pt,
 #ifdef PSA_API_TEST_IPC
 enum tfm_hal_status_t ff_test_uart_irq_init(void *p_pt,
                                             struct irq_load_info_t *p_ildi)
-__attribute__((alias("tfm_egu5_irq_init")));
+__attribute__((alias("tfm_serial1_init")));
 
 #endif

--- a/platform/ext/target/nordic_nrf/common/nrf5340/tfm_peripherals_def.h
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/tfm_peripherals_def.h
@@ -211,15 +211,15 @@ extern struct platform_data_t tfm_peripheral_vmc;
 #define TFM_PERIPHERAL_STD_UART     TFM_PERIPHERAL_UARTE1
 
 #ifdef PSA_API_TEST_IPC
-#define FF_TEST_UART_IRQ         (EGU5_IRQn)
-#define FF_TEST_UART_IRQ_Handler (pal_interrupt_handler)
+#define FF_TEST_UART_IRQ         (TFM_UARTE1_IRQ)
+#define FF_TEST_UART_IRQ_Handler (SPIM1_SPIS1_TWIM1_TWIS1_UARTE1_IRQHandler)
 
 extern struct platform_data_t tfm_peripheral_FF_TEST_NVMEM_REGION;
 extern struct platform_data_t tfm_peripheral_FF_TEST_SERVER_PARTITION_MMIO;
 extern struct platform_data_t tfm_peripheral_FF_TEST_DRIVER_PARTITION_MMIO;
 
-#define FF_TEST_UART_REGION           (&tfm_peripheral_std_uart)
-#define FF_TEST_WATCHDOG_REGION       (&tfm_peripheral_timer0)
+#define FF_TEST_UART_REGION           (TFM_PERIPHERAL_UARTE1)
+#define FF_TEST_WATCHDOG_REGION       (TFM_PERIPHERAL_WDT0)
 #define FF_TEST_NVMEM_REGION          (&tfm_peripheral_FF_TEST_NVMEM_REGION)
 #define FF_TEST_SERVER_PARTITION_MMIO (&tfm_peripheral_FF_TEST_SERVER_PARTITION_MMIO)
 #define FF_TEST_DRIVER_PARTITION_MMIO (&tfm_peripheral_FF_TEST_DRIVER_PARTITION_MMIO)

--- a/platform/ext/target/nordic_nrf/common/nrf9160/mmio_defs.h
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/mmio_defs.h
@@ -166,6 +166,11 @@ const uintptr_t partition_named_mmio_list[] = {
 #if TFM_PERIPHERAL_GPIO0_SECURE
     (uintptr_t)TFM_PERIPHERAL_GPIO0,
 #endif
+#ifdef PSA_API_TEST_IPC
+    (uintptr_t)FF_TEST_NVMEM_REGION,
+    (uintptr_t)FF_TEST_DRIVER_PARTITION_MMIO,
+    (uintptr_t)FF_TEST_SERVER_PARTITION_MMIO,
+#endif
 };
 
 #ifdef __cplusplus

--- a/platform/ext/target/nordic_nrf/common/nrf9160/tfm_interrupts.c
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/tfm_interrupts.c
@@ -536,6 +536,6 @@ enum tfm_hal_status_t tfm_i20_irq_init(void *p_pt,
 #ifdef PSA_API_TEST_IPC
 enum tfm_hal_status_t ff_test_uart_irq_init(void *p_pt,
                                             struct irq_load_info_t *p_ildi)
-__attribute__((alias("tfm_egu5_irq_init")));
+__attribute__((alias("tfm_serial1_init")));
 
 #endif

--- a/platform/ext/target/nordic_nrf/common/nrf9160/tfm_peripherals_def.h
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/tfm_peripherals_def.h
@@ -170,15 +170,15 @@ extern struct platform_data_t tfm_peripheral_gpio0;
 #define TFM_PERIPHERAL_STD_UART     TFM_PERIPHERAL_UARTE1
 
 #ifdef PSA_API_TEST_IPC
-#define FF_TEST_UART_IRQ         (EGU5_IRQn)
-#define FF_TEST_UART_IRQ_Handler (pal_interrupt_handler)
+#define FF_TEST_UART_IRQ         (TFM_UARTE1_IRQ)
+#define FF_TEST_UART_IRQ_Handler (SPIM1_SPIS1_TWIM1_TWIS1_UARTE1_IRQHandler)
 
 extern struct platform_data_t tfm_peripheral_FF_TEST_NVMEM_REGION;
 extern struct platform_data_t tfm_peripheral_FF_TEST_SERVER_PARTITION_MMIO;
 extern struct platform_data_t tfm_peripheral_FF_TEST_DRIVER_PARTITION_MMIO;
 
-#define FF_TEST_UART_REGION           (&tfm_peripheral_std_uart)
-#define FF_TEST_WATCHDOG_REGION       (&tfm_peripheral_timer0)
+#define FF_TEST_UART_REGION           (TFM_PERIPHERAL_UARTE1)
+#define FF_TEST_WATCHDOG_REGION       (TFM_PERIPHERAL_WDT)
 #define FF_TEST_NVMEM_REGION          (&tfm_peripheral_FF_TEST_NVMEM_REGION)
 #define FF_TEST_SERVER_PARTITION_MMIO (&tfm_peripheral_FF_TEST_SERVER_PARTITION_MMIO)
 #define FF_TEST_DRIVER_PARTITION_MMIO (&tfm_peripheral_FF_TEST_DRIVER_PARTITION_MMIO)

--- a/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/tfm_peripherals_config.h
+++ b/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/tfm_peripherals_config.h
@@ -21,8 +21,7 @@ extern "C" {
 #endif
 
 #ifdef PSA_API_TEST_IPC
-#define TFM_PERIPHERAL_EGU5_SECURE 1
-
+#define TFM_PERIPHERAL_UARTE1_SECURE 1
 #define TFM_PERIPHERAL_WDT0_SECURE 1
 #endif
 

--- a/platform/ext/target/nordic_nrf/nrf9160dk_nrf9160/tfm_peripherals_config.h
+++ b/platform/ext/target/nordic_nrf/nrf9160dk_nrf9160/tfm_peripherals_config.h
@@ -21,8 +21,7 @@ extern "C" {
 #endif
 
 #ifdef PSA_API_TEST_IPC
-#define TFM_PERIPHERAL_EGU5_SECURE 1
-
+#define TFM_PERIPHERAL_UARTE1_SECURE 1
 #define TFM_PERIPHERAL_WDT_SECURE 1
 #endif
 


### PR DESCRIPTION
Remove psa_scratch related code.
Update peripheral configurations for nordic_nrf to use UARTE instead of EGU.
Fix wrong path in CMakeLists for 9160.

Change-Id: I1694350d4d96018e0a4568381e93d0d611a6ca76